### PR TITLE
Refine map layout and integrate images folder

### DIFF
--- a/ben-kimim.html
+++ b/ben-kimim.html
@@ -7,14 +7,14 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="css/ben-kimim.css">
     <link rel="stylesheet" href="css/header.css">
-    <link rel="icon" href="assets/images/logo.png" type="image/png">
+    <link rel="icon" href="images/logo.png" type="image/png">
 </head>
 <body>
     <!-- Gizli Header -->
     <header id="hidden-header">
         <div class="container">
             <div class="logo">
-                <img src="assets/images/logo.png" alt="Anlık Deprem Logo">
+                <img src="images/logo.png" alt="Anlık Deprem Logo">
                 <span>Anlık Deprem</span>
             </div>
             <nav>
@@ -44,7 +44,7 @@
         <div class="container">
             <div class="about-content">
                 <div class="about-image">
-                    <img src="assets/images/profile.jpg" alt="Profil Fotoğrafı">
+                    <img src="images/profile.jpg" alt="Profil Fotoğrafı">
                 </div>
                 <div class="about-text">
                     <h2>Ben Kimim?</h2>
@@ -208,7 +208,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <img src="assets/images/logo.png" alt="Anlık Deprem Logo">
+                    <img src="images/logo.png" alt="Anlık Deprem Logo">
                     <h3>Anlık Deprem</h3>
                     <p>Hayat kurtaran bilgiler</p>
                 </div>

--- a/css/ben-kimim.css
+++ b/css/ben-kimim.css
@@ -32,7 +32,7 @@ body {
 
 /* Hero Bölümü */
 .hero {
-    background: linear-gradient(135deg, rgba(211, 47, 47, 0.9), rgba(244, 67, 54, 0.8)), url('assets/images/hero-bg.jpg');
+    background: linear-gradient(135deg, rgba(211, 47, 47, 0.9), rgba(244, 67, 54, 0.8)), url('images/hero-bg.jpg');
     background-size: cover;
     background-position: center;
     color: white;

--- a/css/header.css
+++ b/css/header.css
@@ -6,7 +6,7 @@
     width: 100%;
     background: rgba(33, 33, 33, 0.95);
     backdrop-filter: blur(10px);
-    z-index: 1000;
+    z-index: 2000;
     box-shadow: var(--shadow);
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -32,7 +32,7 @@ body {
 
 /* Hero Bölümü */
 .hero {
-    background: linear-gradient(135deg, rgba(211, 47, 47, 0.9), rgba(244, 67, 54, 0.8)), url('assets/images/hero-bg.jpg');
+    background: linear-gradient(135deg, rgba(211, 47, 47, 0.9), rgba(244, 67, 54, 0.8)), url('images/hero-bg.jpg');
     background-size: cover;
     background-position: center;
     color: white;
@@ -145,6 +145,11 @@ main {
     min-width: 300px;
 }
 
+.map-content {
+    display: flex;
+    align-items: flex-start;
+}
+
 .earthquake-list {
     flex: 1;
     min-width: 300px;
@@ -211,7 +216,7 @@ main {
 
 /* Harita Konteyneri */
 .map-container {
-    height: 980px; /* Harita yüksekliği artırıldı */
+    height: 1470px; /* Harita yüksekliği %50 artırıldı */
     border-radius: 12px;
     overflow: hidden;
     box-shadow: var(--shadow);
@@ -226,11 +231,14 @@ main {
 
 /* Büyüklük Göstergesi */
 .magnitude-legend {
-    margin-top: 20px;
+    margin-top: 0;
+    margin-right: 20px;
     background: white;
     padding: 15px;
     border-radius: 8px;
     box-shadow: var(--shadow);
+    width: 160px;
+    flex-shrink: 0;
 }
 
 .legend-title {
@@ -241,7 +249,8 @@ main {
 
 .legend-items {
     display: flex;
-    gap: 20px;
+    flex-direction: column;
+    gap: 10px;
 }
 
 .legend-item {
@@ -400,6 +409,7 @@ main {
     padding: 80px 0;
     background-color: #f9f9f9;
     margin-top: 60px;
+    flex-basis: 100%;
 }
 
 .features-section h2 {
@@ -614,7 +624,7 @@ footer {
 
 @media (max-width: 576px) {
     .map-container {
-        height: 500px;
+        height: 750px;
     }
     
     .hero {

--- a/deprem-aninda.html
+++ b/deprem-aninda.html
@@ -7,14 +7,14 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="css/deprem-aninda.css">
     <link rel="stylesheet" href="css/header.css">
-    <link rel="icon" href="assets/images/logo.png" type="image/png">
+    <link rel="icon" href="images/logo.png" type="image/png">
 </head>
 <body>
     <!-- Gizli Header -->
     <header id="hidden-header">
         <div class="container">
             <div class="logo">
-                <img src="assets/images/logo.png" alt="Anlık Deprem Logo">
+                <img src="images/logo.png" alt="Anlık Deprem Logo">
                 <span>Anlık Deprem</span>
             </div>
             <nav>
@@ -36,22 +36,22 @@
     <main class="container">
         <section class="safety-guides">
             <div class="guide-card">
-                <div class="guide-icon">
-                    <i class="fas fa-house-damage"></i>
+                <div class="guide-image">
+                    <img src="images/binaicindeyseniz.webp" alt="Bina İçindeyseniz">
                 </div>
                 <h2>Bina İçindeyseniz</h2>
                 <p>Çök-Kapan-Tutun hareketini uygulayın. Pencerelerden ve ağır eşyalardan uzak durun.</p>
             </div>
             <div class="guide-card">
-                <div class="guide-icon">
-                    <i class="fas fa-road"></i>
+                <div class="guide-image">
+                    <img src="images/disaridayken.webp" alt="Dışarıdaysanız">
                 </div>
                 <h2>Dışarıdaysanız</h2>
                 <p>Binalardan, ağaçlardan ve devrilebilecek cisimlerden uzak açık alanlara yönelin.</p>
             </div>
             <div class="guide-card">
-                <div class="guide-icon">
-                    <i class="fas fa-car"></i>
+                <div class="guide-image">
+                    <img src="images/arackullarnirken.webp" alt="Araç Kullanırken">
                 </div>
                 <h2>Araç Kullanırken</h2>
                 <p>Güvenli bir şekilde kenara çekin, köprü ve tünellerden uzak durun.</p>
@@ -84,7 +84,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <img src="assets/images/logo.png" alt="Anlık Deprem Logo">
+                    <img src="images/logo.png" alt="Anlık Deprem Logo">
                     <h3>Anlık Deprem</h3>
                     <p>Hayat kurtaran bilgiler</p>
                 </div>

--- a/ilk-yardim-cantasi.html
+++ b/ilk-yardim-cantasi.html
@@ -7,14 +7,14 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="css/ilk-yardim.css">
     <link rel="stylesheet" href="css/header.css">
-    <link rel="icon" href="assets/images/logo.png" type="image/png">
+    <link rel="icon" href="images/logo.png" type="image/png">
 </head>
 <body>
     <!-- Gizli Header -->
     <header id="hidden-header">
         <div class="container">
             <div class="logo">
-                <img src="assets/images/logo.png" alt="Anlık Deprem Logo">
+                <img src="images/logo.png" alt="Anlık Deprem Logo">
                 <span>Anlık Deprem</span>
             </div>
             <nav>
@@ -171,7 +171,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <img src="assets/images/logo.png" alt="Anlık Deprem Logo">
+                    <img src="images/logo.png" alt="Anlık Deprem Logo">
                     <h3>Anlık Deprem</h3>
                     <p>Hayat kurtaran bilgiler</p>
                 </div>

--- a/index.html
+++ b/index.html
@@ -8,14 +8,14 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="css/style.css">
     <link rel="stylesheet" href="css/header.css">
-    <link rel="icon" href="assets/images/logo.png" type="image/png">
+    <link rel="icon" href="images/logo.png" type="image/png">
 </head>
 <body>
     <!-- Gizli Header -->
     <header id="hidden-header">
         <div class="container">
             <div class="logo">
-                <img src="assets/images/logo.png" alt="Anlık Deprem Logo">
+                <img src="images/logo.png" alt="Anlık Deprem Logo">
                 <span>Anlık Deprem</span>
             </div>
             <nav>
@@ -69,27 +69,29 @@
                     </button>
                 </div>
             </div>
-            
-            <!-- Harita Alanı -->
-            <div id="map" class="map-container"></div>
-            
-            <!-- Büyüklük Göstergesi -->
-            <div class="magnitude-legend">
-                <div class="legend-title">Deprem Büyüklüğü</div>
-                <div class="legend-items">
-                    <div class="legend-item">
-                        <div class="color-box" style="background-color: rgba(255, 0, 0, 0.3);"></div>
-                        <span>3.0 - 4.0</span>
-                    </div>
-                    <div class="legend-item">
-                        <div class="color-box" style="background-color: rgba(255, 0, 0, 0.6);"></div>
-                        <span>4.0 - 5.0</span>
-                    </div>
-                    <div class="legend-item">
-                        <div class="color-box" style="background-color: rgba(255, 0, 0, 0.9);"></div>
-                        <span>5.0+</span>
+
+            <div class="map-content">
+                <!-- Büyüklük Göstergesi -->
+                <div class="magnitude-legend">
+                    <div class="legend-title">Deprem Büyüklüğü</div>
+                    <div class="legend-items">
+                        <div class="legend-item">
+                            <div class="color-box" style="background-color: rgba(255, 0, 0, 0.3);"></div>
+                            <span>3.0 - 4.0</span>
+                        </div>
+                        <div class="legend-item">
+                            <div class="color-box" style="background-color: rgba(255, 0, 0, 0.6);"></div>
+                            <span>4.0 - 5.0</span>
+                        </div>
+                        <div class="legend-item">
+                            <div class="color-box" style="background-color: rgba(255, 0, 0, 0.9);"></div>
+                            <span>5.0+</span>
+                        </div>
                     </div>
                 </div>
+
+                <!-- Harita Alanı -->
+                <div id="map" class="map-container"></div>
             </div>
         </div>
 
@@ -112,51 +114,50 @@
                 <div class="loading">Depremler yükleniyor...</div>
             </div>
         </aside>
-    </main>
-
-    <!-- Özellikler Bölümü -->
-    <section class="features-section">
-        <div class="container">
-            <h2>Platform Özellikleri</h2>
-            <div class="features-grid">
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <i class="fas fa-map-marked-alt"></i>
+        <!-- Özellikler Bölümü -->
+        <section class="features-section">
+            <div class="container">
+                <h2>Platform Özellikleri</h2>
+                <div class="features-grid">
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <i class="fas fa-map-marked-alt"></i>
+                        </div>
+                        <h3>Gerçek Zamanlı Harita</h3>
+                        <p>USGS verileri ile güncellenen Türkiye deprem haritası</p>
                     </div>
-                    <h3>Gerçek Zamanlı Harita</h3>
-                    <p>USGS verileri ile güncellenen Türkiye deprem haritası</p>
-                </div>
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <i class="fas fa-exclamation-triangle"></i>
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <i class="fas fa-exclamation-triangle"></i>
+                        </div>
+                        <h3>Deprem Anında</h3>
+                        <p>Hayat kurtaran bilgiler ve güvenli alanlar</p>
                     </div>
-                    <h3>Deprem Anında</h3>
-                    <p>Hayat kurtaran bilgiler ve güvenli alanlar</p>
-                </div>
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <i class="fas fa-first-aid"></i>
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <i class="fas fa-first-aid"></i>
+                        </div>
+                        <h3>İlk Yardım Çantası</h3>
+                        <p>Videolu anlatımlarla çantanızı hazırlayın</p>
                     </div>
-                    <h3>İlk Yardım Çantası</h3>
-                    <p>Videolu anlatımlarla çantanızı hazırlayın</p>
-                </div>
-                <div class="feature-card">
-                    <div class="feature-icon">
-                        <i class="fas fa-bell"></i>
+                    <div class="feature-card">
+                        <div class="feature-icon">
+                            <i class="fas fa-bell"></i>
+                        </div>
+                        <h3>Anlık Bildirimler</h3>
+                        <p>Önemli depremler hakkında anlık bildirimler</p>
                     </div>
-                    <h3>Anlık Bildirimler</h3>
-                    <p>Önemli depremler hakkında anlık bildirimler</p>
                 </div>
             </div>
-        </div>
-    </section>
+        </section>
+    </main>
 
     <!-- Footer -->
     <footer>
         <div class="container">
             <div class="footer-content">
                 <div class="footer-logo">
-                    <img src="assets/images/logo.png" alt="Anlık Deprem Logo">
+                    <img src="images/logo.png" alt="Anlık Deprem Logo">
                     <h3>Anlık Deprem</h3>
                     <p>Hayat kurtaran bilgiler</p>
                 </div>


### PR DESCRIPTION
## Summary
- Move magnitude legend to a left-hand vertical panel and enlarge the map area.
- Ensure header remains above Leaflet attribution and relocate features section below main content.
- Replace emergency guide icons with user-supplied images and remove placeholder binaries.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba84234898832785a929c1d21bd768