### PR TITLE
Link header logo to home and add F5 scroll to top

### DIFF
--- a/ben-kimim.html
+++ b/ben-kimim.html
@@ -15,10 +15,10 @@
     <!-- Gizli Header -->
     <header id="hidden-header">
         <div class="container">
-            <div class="logo">
+            <a href="index.html" class="logo">
                 <img src="images/logo.png" alt="Anlık Deprem Logo">
                 <span>Anlık Deprem</span>
-            </div>
+            </a>
             <nav>
                 <a href="index.html">Ana Sayfa</a>
                 <a href="deprem-aninda.html">Deprem Anında</a>

--- a/css/header.css
+++ b/css/header.css
@@ -21,6 +21,7 @@
     display: flex;
     align-items: center;
     gap: 10px;
+    text-decoration: none;
 }
 
 .logo img {

--- a/deprem-aninda.html
+++ b/deprem-aninda.html
@@ -15,10 +15,10 @@
     <!-- Gizli Header -->
     <header id="hidden-header">
         <div class="container">
-            <div class="logo">
+            <a href="index.html" class="logo">
                 <img src="images/logo.png" alt="Anlık Deprem Logo">
                 <span>Anlık Deprem</span>
-            </div>
+            </a>
             <nav>
                 <a href="index.html">Ana Sayfa</a>
                 <a href="deprem-aninda.html" class="active">Deprem Anında</a>

--- a/ilk-yardim-cantasi.html
+++ b/ilk-yardim-cantasi.html
@@ -18,10 +18,10 @@
     <!-- Gizli Header -->
     <header id="hidden-header">
       <div class="container">
-        <div class="logo">
+        <a href="index.html" class="logo">
           <img src="images/logo.png" alt="Anlık Deprem Logo" />
           <span>Anlık Deprem</span>
-        </div>
+        </a>
         <nav>
           <a href="index.html">Ana Sayfa</a>
           <a href="deprem-aninda.html">Deprem Anında</a>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
     <!-- Gizli Header -->
     <header id="hidden-header">
         <div class="container">
-            <div class="logo">
+            <a href="index.html" class="logo">
                 <img src="images/logo.png" alt="Anlık Deprem Logo">
                 <span>Anlık Deprem</span>
-            </div>
+            </a>
             <nav>
                 <a href="index.html" class="active">Ana Sayfa</a>
                 <a href="deprem-aninda.html">Deprem Anında</a>

--- a/js/header.js
+++ b/js/header.js
@@ -3,3 +3,11 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!hiddenHeader) return;
     hiddenHeader.style.top = '0';
 });
+
+document.addEventListener('keydown', (event) => {
+    if (event.key === 'F5') {
+        event.preventDefault();
+        history.replaceState(null, '', window.location.pathname + window.location.search);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+});


### PR DESCRIPTION
## Summary
- Make logo in header link back to index page on every screen
- Capture F5 key to smoothly scroll to top of page
- Remove default underline from logo link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba93a8483083278d000f1e2515ad51