### PR TITLE
Add blog section with safety posts and navigation

### DIFF
--- a/ben-kimim.html
+++ b/ben-kimim.html
@@ -24,6 +24,7 @@
                 <a href="deprem-aninda.html">Deprem Anında</a>
                 <a href="ilk-yardim-cantasi.html">İlk Yardım Çantası</a>
                 <a href="ben-kimim.html" class="active">Ben Kimim</a>
+                <a href="blog.html">Blog</a>
             </nav>
         </div>
     </header>
@@ -235,6 +236,7 @@
                             <li><a href="deprem-aninda.html">Deprem Anında</a></li>
                             <li><a href="ilk-yardim-cantasi.html">İlk Yardım Çantası</a></li>
                             <li><a href="ben-kimim.html">Ben Kimim</a></li>
+                            <li><a href="blog.html">Blog</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">

--- a/blog-arac-kullanirken.html
+++ b/blog-arac-kullanirken.html
@@ -3,11 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deprem Anında - Anlık Deprem</title>
-    <meta name="description" content="anlikdeprem deprem rehberi: Bina içindeyseniz, dışarıdaysanız veya araç kullanırken güvenlik ipuçları.">
-    <meta name="keywords" content="anlikdeprem, deprem anında, deprem güvenlik rehberi, çök kapan tutun">
+    <title>Araç Kullanırken - Anlık Deprem</title>
+    <meta name="description" content="Deprem sırasında araç kullanırken dikkat edilmesi gerekenler.">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="css/deprem-aninda.css">
+    <link rel="stylesheet" href="css/blog.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="icon" href="images/logo.png" type="image/png">
 </head>
@@ -21,67 +20,22 @@
             </a>
             <nav>
                 <a href="index.html">Ana Sayfa</a>
-                <a href="deprem-aninda.html" class="active">Deprem Anında</a>
+                <a href="deprem-aninda.html">Deprem Anında</a>
                 <a href="ilk-yardim-cantasi.html">İlk Yardım Çantası</a>
                 <a href="ben-kimim.html">Ben Kimim</a>
-                <a href="blog.html">Blog</a>
+                <a href="blog.html" class="active">Blog</a>
             </nav>
         </div>
     </header>
 
-    <header class="page-header">
-        <div class="container">
-            <h1>Deprem Anında Güvenlik Rehberi</h1>
-            <p>Deprem sırasında kendinizi ve sevdiklerinizi koruyun</p>
-            <p class="seo-text">Güncel bilgiler için <strong>anlikdeprem</strong> rehberinizi takip edin.</p>
-        </div>
-    </header>
-
     <main class="container">
-        <section class="safety-guides">
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/binaicindeyseniz.webp" alt="anlikdeprem Bina İçindeyseniz">
-                </div>
-                <h2>Bina İçindeyseniz</h2>
-                <p>Çök-Kapan-Tutun hareketini uygulayın. Pencerelerden ve ağır eşyalardan uzak durun.</p>
-            </div>
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/disaridayken.webp" alt="anlikdeprem Dışarıdaysanız">
-                </div>
-                <h2>Dışarıdaysanız</h2>
-                <p>Binalardan, ağaçlardan ve devrilebilecek cisimlerden uzak açık alanlara yönelin.</p>
-            </div>
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/arackullarnirken.webp" alt="anlikdeprem Araç Kullanırken">
-                </div>
-                <h2>Araç Kullanırken</h2>
-                <p>Güvenli bir şekilde kenara çekin, köprü ve tünellerden uzak durun.</p>
-            </div>
-        </section>
-
-        <section class="emergency-contacts">
-            <h2>Acil İletişim Numaraları</h2>
-            <div class="contact-grid">
-                <a class="contact-item" href="tel:112">
-                    <div class="contact-icon">112</div>
-                    <h3>Acil Çağrı Merkezi</h3>
-                    <p>İtfaiye, ambulans ve polis</p>
-                </a>
-                <a class="contact-item" href="tel:122">
-                    <div class="contact-icon">AFAD</div>
-                    <h3>Afet ve Acil Durum Yönetimi</h3>
-                    <p>www.afad.gov.tr</p>
-                </a>
-                <a class="contact-item" href="tel:02122170410">
-                    <div class="contact-icon">AKUT</div>
-                    <h3>Arama Kurtarma</h3>
-                    <p>www.akut.org.tr</p>
-                </a>
-            </div>
-        </section>
+        <article class="blog-article">
+            <img src="images/arackullarnirken.webp" alt="Araç kullanırken">
+            <h1>Araç Kullanırken</h1>
+            <p>Deprem sırasında araç kullanıyorsanız ilk yapmanız gereken aracı güvenli bir şekilde kenara çekmektir. Köprüler, tüneller ve üst geçitler gibi riskli bölgelerden uzak durun.</p>
+            <p>Aracı durdurduktan sonra, mümkünse trafik akışını engellemeyecek bir alanda bekleyin ve el frenini çekin. Sarsıntı sona erene kadar araç içinde kalmak genellikle en güvenli seçenektir.</p>
+            <p>Sarsıntı bittikten sonra yolun durumunu kontrol edin ve güvenli olduğundan emin olduktan sonra yola devam edin. Radyo veya yetkililerden gelecek uyarıları takip ederek hareket edin.</p>
+        </article>
     </main>
 
     <footer>

--- a/blog-bina-icindeyseniz.html
+++ b/blog-bina-icindeyseniz.html
@@ -3,11 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deprem Anında - Anlık Deprem</title>
-    <meta name="description" content="anlikdeprem deprem rehberi: Bina içindeyseniz, dışarıdaysanız veya araç kullanırken güvenlik ipuçları.">
-    <meta name="keywords" content="anlikdeprem, deprem anında, deprem güvenlik rehberi, çök kapan tutun">
+    <title>Bina İçindeyseniz - Anlık Deprem</title>
+    <meta name="description" content="Deprem sırasında bina içindeyseniz yapmanız gereken adımlar.">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="css/deprem-aninda.css">
+    <link rel="stylesheet" href="css/blog.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="icon" href="images/logo.png" type="image/png">
 </head>
@@ -21,67 +20,22 @@
             </a>
             <nav>
                 <a href="index.html">Ana Sayfa</a>
-                <a href="deprem-aninda.html" class="active">Deprem Anında</a>
+                <a href="deprem-aninda.html">Deprem Anında</a>
                 <a href="ilk-yardim-cantasi.html">İlk Yardım Çantası</a>
                 <a href="ben-kimim.html">Ben Kimim</a>
-                <a href="blog.html">Blog</a>
+                <a href="blog.html" class="active">Blog</a>
             </nav>
         </div>
     </header>
 
-    <header class="page-header">
-        <div class="container">
-            <h1>Deprem Anında Güvenlik Rehberi</h1>
-            <p>Deprem sırasında kendinizi ve sevdiklerinizi koruyun</p>
-            <p class="seo-text">Güncel bilgiler için <strong>anlikdeprem</strong> rehberinizi takip edin.</p>
-        </div>
-    </header>
-
     <main class="container">
-        <section class="safety-guides">
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/binaicindeyseniz.webp" alt="anlikdeprem Bina İçindeyseniz">
-                </div>
-                <h2>Bina İçindeyseniz</h2>
-                <p>Çök-Kapan-Tutun hareketini uygulayın. Pencerelerden ve ağır eşyalardan uzak durun.</p>
-            </div>
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/disaridayken.webp" alt="anlikdeprem Dışarıdaysanız">
-                </div>
-                <h2>Dışarıdaysanız</h2>
-                <p>Binalardan, ağaçlardan ve devrilebilecek cisimlerden uzak açık alanlara yönelin.</p>
-            </div>
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/arackullarnirken.webp" alt="anlikdeprem Araç Kullanırken">
-                </div>
-                <h2>Araç Kullanırken</h2>
-                <p>Güvenli bir şekilde kenara çekin, köprü ve tünellerden uzak durun.</p>
-            </div>
-        </section>
-
-        <section class="emergency-contacts">
-            <h2>Acil İletişim Numaraları</h2>
-            <div class="contact-grid">
-                <a class="contact-item" href="tel:112">
-                    <div class="contact-icon">112</div>
-                    <h3>Acil Çağrı Merkezi</h3>
-                    <p>İtfaiye, ambulans ve polis</p>
-                </a>
-                <a class="contact-item" href="tel:122">
-                    <div class="contact-icon">AFAD</div>
-                    <h3>Afet ve Acil Durum Yönetimi</h3>
-                    <p>www.afad.gov.tr</p>
-                </a>
-                <a class="contact-item" href="tel:02122170410">
-                    <div class="contact-icon">AKUT</div>
-                    <h3>Arama Kurtarma</h3>
-                    <p>www.akut.org.tr</p>
-                </a>
-            </div>
-        </section>
+        <article class="blog-article">
+            <img src="images/binaicindeyseniz.webp" alt="Bina içindeyseniz">
+            <h1>Bina İçindeyseniz</h1>
+            <p>Deprem anında bina içindeyseniz öncelikle sakin kalmaya çalışın. Panik, yanlış hareketlere neden olabilir. Çök-Kapan-Tutun hareketini uygulayın ve sağlam bir masa veya sıra gibi koruma sağlayabilecek eşyaların altına girin.</p>
+            <p>Pencerelerden, büyük mobilyalardan ve devrilebilecek eşyalardan uzak durun. Sarsıntı geçene kadar bulunduğunuz yerde kalın ve merdivenleri kullanmayın. Elektrik kesilmesi durumunda karanlıkta düşmemek için elinizin altında bir el feneri bulundurmanız önemlidir.</p>
+            <p>Sarsıntı sona erdikten sonra çıkış yollarını kontrol edin ve güvenliyse binayı terk edin. Artçı sarsıntılara karşı dikkatli olun ve açık alanlarda toplanma bölgelerine yönelin.</p>
+        </article>
     </main>
 
     <footer>

--- a/blog-disaridaysaniz.html
+++ b/blog-disaridaysaniz.html
@@ -3,11 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deprem Anında - Anlık Deprem</title>
-    <meta name="description" content="anlikdeprem deprem rehberi: Bina içindeyseniz, dışarıdaysanız veya araç kullanırken güvenlik ipuçları.">
-    <meta name="keywords" content="anlikdeprem, deprem anında, deprem güvenlik rehberi, çök kapan tutun">
+    <title>Dışarıdaysanız - Anlık Deprem</title>
+    <meta name="description" content="Deprem sırasında dışarıdaysanız nasıl hareket etmelisiniz?">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="css/deprem-aninda.css">
+    <link rel="stylesheet" href="css/blog.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="icon" href="images/logo.png" type="image/png">
 </head>
@@ -21,67 +20,22 @@
             </a>
             <nav>
                 <a href="index.html">Ana Sayfa</a>
-                <a href="deprem-aninda.html" class="active">Deprem Anında</a>
+                <a href="deprem-aninda.html">Deprem Anında</a>
                 <a href="ilk-yardim-cantasi.html">İlk Yardım Çantası</a>
                 <a href="ben-kimim.html">Ben Kimim</a>
-                <a href="blog.html">Blog</a>
+                <a href="blog.html" class="active">Blog</a>
             </nav>
         </div>
     </header>
 
-    <header class="page-header">
-        <div class="container">
-            <h1>Deprem Anında Güvenlik Rehberi</h1>
-            <p>Deprem sırasında kendinizi ve sevdiklerinizi koruyun</p>
-            <p class="seo-text">Güncel bilgiler için <strong>anlikdeprem</strong> rehberinizi takip edin.</p>
-        </div>
-    </header>
-
     <main class="container">
-        <section class="safety-guides">
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/binaicindeyseniz.webp" alt="anlikdeprem Bina İçindeyseniz">
-                </div>
-                <h2>Bina İçindeyseniz</h2>
-                <p>Çök-Kapan-Tutun hareketini uygulayın. Pencerelerden ve ağır eşyalardan uzak durun.</p>
-            </div>
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/disaridayken.webp" alt="anlikdeprem Dışarıdaysanız">
-                </div>
-                <h2>Dışarıdaysanız</h2>
-                <p>Binalardan, ağaçlardan ve devrilebilecek cisimlerden uzak açık alanlara yönelin.</p>
-            </div>
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/arackullarnirken.webp" alt="anlikdeprem Araç Kullanırken">
-                </div>
-                <h2>Araç Kullanırken</h2>
-                <p>Güvenli bir şekilde kenara çekin, köprü ve tünellerden uzak durun.</p>
-            </div>
-        </section>
-
-        <section class="emergency-contacts">
-            <h2>Acil İletişim Numaraları</h2>
-            <div class="contact-grid">
-                <a class="contact-item" href="tel:112">
-                    <div class="contact-icon">112</div>
-                    <h3>Acil Çağrı Merkezi</h3>
-                    <p>İtfaiye, ambulans ve polis</p>
-                </a>
-                <a class="contact-item" href="tel:122">
-                    <div class="contact-icon">AFAD</div>
-                    <h3>Afet ve Acil Durum Yönetimi</h3>
-                    <p>www.afad.gov.tr</p>
-                </a>
-                <a class="contact-item" href="tel:02122170410">
-                    <div class="contact-icon">AKUT</div>
-                    <h3>Arama Kurtarma</h3>
-                    <p>www.akut.org.tr</p>
-                </a>
-            </div>
-        </section>
+        <article class="blog-article">
+            <img src="images/disaridayken.webp" alt="Dışarıdaysanız">
+            <h1>Dışarıdaysanız</h1>
+            <p>Deprem anında dışarıdaysanız binalardan, ağaçlardan ve devrilebilecek objelerden uzaklaşın. Açık alanlarda durmaya çalışın ve üzerinize düşebilecek her türlü nesneden kaçının.</p>
+            <p>Elektrik hatları, reklam panoları ve cam vitrinler gibi tehlike oluşturabilecek alanlardan uzak durmak hayati önem taşır. Eğer kalabalık bir yerdeyseniz izdiham riskine karşı sakin ve kontrollü hareket edin.</p>
+            <p>Sarsıntı geçtikten sonra artçı depremlere karşı tetikte olun ve mümkünse açık alanlarda toplanma bölgelerine gidin. Güvenliğiniz için yetkililerin uyarılarını takip edin.</p>
+        </article>
     </main>
 
     <footer>

--- a/blog.html
+++ b/blog.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deprem Anında - Anlık Deprem</title>
-    <meta name="description" content="anlikdeprem deprem rehberi: Bina içindeyseniz, dışarıdaysanız veya araç kullanırken güvenlik ipuçları.">
-    <meta name="keywords" content="anlikdeprem, deprem anında, deprem güvenlik rehberi, çök kapan tutun">
+    <title>Blog - Anlık Deprem</title>
+    <meta name="description" content="anlikdeprem blogu: Deprem sırasında yapılması gerekenler hakkında bilgilendirici yazılar.">
+    <meta name="keywords" content="anlikdeprem, deprem blog, bina içindeyseniz, dışarıdaysanız, araç kullanırken">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="css/deprem-aninda.css">
+    <link rel="stylesheet" href="css/blog.css">
     <link rel="stylesheet" href="css/header.css">
     <link rel="icon" href="images/logo.png" type="image/png">
 </head>
@@ -21,66 +21,44 @@
             </a>
             <nav>
                 <a href="index.html">Ana Sayfa</a>
-                <a href="deprem-aninda.html" class="active">Deprem Anında</a>
+                <a href="deprem-aninda.html">Deprem Anında</a>
                 <a href="ilk-yardim-cantasi.html">İlk Yardım Çantası</a>
                 <a href="ben-kimim.html">Ben Kimim</a>
-                <a href="blog.html">Blog</a>
+                <a href="blog.html" class="active">Blog</a>
             </nav>
         </div>
     </header>
 
     <header class="page-header">
         <div class="container">
-            <h1>Deprem Anında Güvenlik Rehberi</h1>
-            <p>Deprem sırasında kendinizi ve sevdiklerinizi koruyun</p>
-            <p class="seo-text">Güncel bilgiler için <strong>anlikdeprem</strong> rehberinizi takip edin.</p>
+            <h1>Deprem Blogu</h1>
+            <p>Deprem sırasında nasıl davranmalısınız?</p>
         </div>
     </header>
 
     <main class="container">
-        <section class="safety-guides">
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/binaicindeyseniz.webp" alt="anlikdeprem Bina İçindeyseniz">
+        <section class="blog-list">
+            <a class="blog-card" href="blog-bina-icindeyseniz.html">
+                <div class="blog-image">
+                    <img src="images/binaicindeyseniz.webp" alt="Bina içindeyseniz">
                 </div>
                 <h2>Bina İçindeyseniz</h2>
-                <p>Çök-Kapan-Tutun hareketini uygulayın. Pencerelerden ve ağır eşyalardan uzak durun.</p>
-            </div>
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/disaridayken.webp" alt="anlikdeprem Dışarıdaysanız">
+                <p>Çök-Kapan-Tutun hareketini uygulayın. Pencerelerden uzak durun.</p>
+            </a>
+            <a class="blog-card" href="blog-disaridaysaniz.html">
+                <div class="blog-image">
+                    <img src="images/disaridayken.webp" alt="Dışarıdaysanız">
                 </div>
                 <h2>Dışarıdaysanız</h2>
                 <p>Binalardan, ağaçlardan ve devrilebilecek cisimlerden uzak açık alanlara yönelin.</p>
-            </div>
-            <div class="guide-card">
-                <div class="guide-image">
-                    <img src="images/arackullarnirken.webp" alt="anlikdeprem Araç Kullanırken">
+            </a>
+            <a class="blog-card" href="blog-arac-kullanirken.html">
+                <div class="blog-image">
+                    <img src="images/arackullarnirken.webp" alt="Araç kullanırken">
                 </div>
                 <h2>Araç Kullanırken</h2>
                 <p>Güvenli bir şekilde kenara çekin, köprü ve tünellerden uzak durun.</p>
-            </div>
-        </section>
-
-        <section class="emergency-contacts">
-            <h2>Acil İletişim Numaraları</h2>
-            <div class="contact-grid">
-                <a class="contact-item" href="tel:112">
-                    <div class="contact-icon">112</div>
-                    <h3>Acil Çağrı Merkezi</h3>
-                    <p>İtfaiye, ambulans ve polis</p>
-                </a>
-                <a class="contact-item" href="tel:122">
-                    <div class="contact-icon">AFAD</div>
-                    <h3>Afet ve Acil Durum Yönetimi</h3>
-                    <p>www.afad.gov.tr</p>
-                </a>
-                <a class="contact-item" href="tel:02122170410">
-                    <div class="contact-icon">AKUT</div>
-                    <h3>Arama Kurtarma</h3>
-                    <p>www.akut.org.tr</p>
-                </a>
-            </div>
+            </a>
         </section>
     </main>
 

--- a/css/blog.css
+++ b/css/blog.css
@@ -1,0 +1,196 @@
+/* Genel Ayarlar */
+:root {
+    --primary-color: #d32f2f;
+    --secondary-color: #f44336;
+    --dark-color: #212121;
+    --light-color: #f5f5f5;
+    --text-color: #333;
+    --shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+    --transition: all 0.3s ease;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background-color: #f9f9f9;
+    color: var(--text-color);
+    line-height: 1.6;
+    scroll-behavior: smooth;
+}
+
+.container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+/* Sayfa Header */
+.page-header {
+    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+    color: white;
+    padding: 120px 0 60px;
+    text-align: center;
+    margin-top: 0;
+}
+
+.page-header h1 {
+    font-size: 36px;
+    margin-bottom: 10px;
+}
+
+.page-header p {
+    font-size: 18px;
+    opacity: 0.9;
+}
+
+/* Blog Liste */
+.blog-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 30px;
+    margin: 60px 0;
+}
+
+.blog-card {
+    background: white;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow);
+    transition: var(--transition);
+    text-decoration: none;
+    color: inherit;
+}
+
+.blog-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
+}
+
+.blog-image {
+    height: 200px;
+    overflow: hidden;
+}
+
+.blog-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: var(--transition);
+}
+
+.blog-card:hover .blog-image img {
+    transform: scale(1.05);
+}
+
+.blog-card h2 {
+    padding: 20px 20px 10px;
+    font-size: 24px;
+    color: var(--dark-color);
+}
+
+.blog-card p {
+    padding: 0 20px 20px;
+    color: #666;
+}
+
+/* Blog Makalesi */
+.blog-article {
+    max-width: 800px;
+    margin: 60px auto;
+}
+
+.blog-article img {
+    width: 100%;
+    border-radius: 12px;
+    margin-bottom: 20px;
+}
+
+.blog-article h1 {
+    font-size: 32px;
+    margin-bottom: 20px;
+    color: var(--dark-color);
+}
+
+.blog-article p {
+    margin-bottom: 15px;
+}
+
+/* Footer */
+footer {
+    background: var(--dark-color);
+    color: white;
+    text-align: center;
+    padding: 20px 0;
+    margin-top: 60px;
+}
+
+.footer-content {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-bottom: 50px;
+}
+
+.footer-logo {
+    flex: 1;
+    min-width: 250px;
+    margin-bottom: 30px;
+}
+
+.footer-logo img {
+    height: 50px;
+    margin-bottom: 15px;
+}
+
+.footer-logo h3 {
+    font-size: 22px;
+    margin-bottom: 10px;
+}
+
+.footer-logo p {
+    color: #ccc;
+}
+
+.footer-links {
+    flex: 2;
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.footer-column {
+    min-width: 200px;
+    margin-bottom: 30px;
+}
+
+.footer-column h4 {
+    margin-bottom: 15px;
+    color: var(--secondary-color);
+}
+
+.footer-column ul {
+    list-style: none;
+}
+
+.footer-column ul li a {
+    color: #fff;
+    text-decoration: none;
+    transition: var(--transition);
+}
+
+.footer-column ul li a:hover {
+    color: var(--secondary-color);
+}
+
+.footer-bottom {
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    padding-top: 20px;
+    color: #bbb;
+    font-size: 14px;
+}

--- a/ilk-yardim-cantasi.html
+++ b/ilk-yardim-cantasi.html
@@ -29,6 +29,7 @@
             >İlk Yardım Çantası</a
           >
           <a href="ben-kimim.html">Ben Kimim</a>
+          <a href="blog.html">Blog</a>
         </nav>
       </div>
     </header>
@@ -228,6 +229,7 @@
                   <a href="ilk-yardim-cantasi.html">İlk Yardım Çantası</a>
                 </li>
                 <li><a href="ben-kimim.html">Ben Kimim</a></li>
+                            <li><a href="blog.html">Blog</a></li>
               </ul>
             </div>
             <div class="footer-column">

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
                 <a href="deprem-aninda.html">Deprem Anında</a>
                 <a href="ilk-yardim-cantasi.html">İlk Yardım Çantası</a>
                 <a href="ben-kimim.html">Ben Kimim</a>
+                <a href="blog.html">Blog</a>
             </nav>
         </div>
     </header>
@@ -169,6 +170,7 @@
                             <li><a href="deprem-aninda.html">Deprem Anında</a></li>
                             <li><a href="ilk-yardim-cantasi.html">İlk Yardım Çantası</a></li>
                             <li><a href="ben-kimim.html">Ben Kimim</a></li>
+                            <li><a href="blog.html">Blog</a></li>
                         </ul>
                     </div>
                     <div class="footer-column">


### PR DESCRIPTION
## Summary
- Create blog landing page with cards linking to safety articles
- Add blog pages for indoor, outdoor, and in-vehicle earthquake guidance
- Link blog section from header and footer across site

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9493f66483278a2cf3980c4e0826